### PR TITLE
Guard against alert routes that have dropped of schedule

### DIFF
--- a/src/utils/alertsFromGtfs.js
+++ b/src/utils/alertsFromGtfs.js
@@ -55,7 +55,7 @@ function routesFromAlert (routesById, alert) {
     !!(informedEntity.routeId)
   ).map((informedEntity) =>
     routesById[informedEntity.routeId]
-  ))]
+  ))].filter((route) => !!(route))
 }
 
 function transformToReactData (gtfsSchedule, routesById, alert) {


### PR DESCRIPTION
Closes #206

It was the 34/35, which I'm guessing were fully removed from the schedule file since it's summer.

