### PR TITLE
Only depend on alert length for alert rotation

### DIFF
--- a/src/components/AlertCarousel.jsx
+++ b/src/components/AlertCarousel.jsx
@@ -6,11 +6,15 @@ export default function AlertCarousel({ alerts }) {
   const [alertIndex, setAlertIndex] = useState(0);
 
   useEffect(() => {
+    if (alerts.length <= 1) {
+      return;
+    }
+
     const interval = setInterval(() => {
       setAlertIndex((index) => (index + 1) % alerts.length);
     }, 20000);
     return () => clearInterval(interval);
-  }, [alerts]);
+  }, [alerts.length]);
 
   const currentAlert = alerts[alertIndex];
 


### PR DESCRIPTION
There was some more ( :bike: ) discussion in the office about alert-rotation timing yesterday and I noticed that the alerts weren't _actually_ rotating every 20 seconds. The first rotation happens after 20 seconds, but then the next one happens 30 seconds after that. I _think_ that this is because the effect depends on `alerts` which changes every time we fetch them from the server. So, the timeline is:

|  | time | event | timing |
|---|------|--------- |----------|
| A | 0:00 | page load |  |
| B | 0:20 | alert rotates | A + 20 |
| C | 0:30 | alerts fetched | A + 30 |
| D | 0:50 | alert rotates | **C** + 20 |
| E | 1:00 | alerts fetched | C + 30 |
| F | 1:20 | alert rotates | **E** + 20 |

Since the effect only depends on the _number_ of alerts, I think it's okay to depend only on `[alerts.length]`.