### PR TITLE
Add indicator for how long the alert will be displayed

### DIFF
--- a/src/components/AlertCarousel.jsx
+++ b/src/components/AlertCarousel.jsx
@@ -1,20 +1,11 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import useAlertRotation from "../hooks/useAlertRotation.js";
 import classNames from "./AlertCarousel.module.css";
 import AlertRoute from "./AlertRoute.jsx";
 
 export default function AlertCarousel({ alerts }) {
   const [alertIndex, setAlertIndex] = useState(0);
-
-  useEffect(() => {
-    if (alerts.length <= 1) {
-      return;
-    }
-
-    const interval = setInterval(() => {
-      setAlertIndex((index) => (index + 1) % alerts.length);
-    }, 20000);
-    return () => clearInterval(interval);
-  }, [alerts.length]);
+  useAlertRotation(alerts.length, setAlertIndex);
 
   const currentAlert = alerts[alertIndex];
 

--- a/src/components/AlertCarousel.jsx
+++ b/src/components/AlertCarousel.jsx
@@ -48,6 +48,11 @@ export default function AlertCarousel({ alerts }) {
           </div>
           <div>{currentAlert.description}</div>
         </div>
+        {alerts.length > 1 && (
+          <div className={classNames["countdown"]} key={currentAlert.id}>
+            <div className={classNames["countdown-bar"]} />
+          </div>
+        )}
       </div>
     )
   );

--- a/src/components/AlertCarousel.jsx
+++ b/src/components/AlertCarousel.jsx
@@ -1,11 +1,14 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import useAlertRotation from "../hooks/useAlertRotation.js";
 import classNames from "./AlertCarousel.module.css";
 import AlertRoute from "./AlertRoute.jsx";
 
+const ROTATION_INTERVAL = 20000;
+
 export default function AlertCarousel({ alerts }) {
+  const animationStyle = useMemo(() => ({ animationDuration: `${ROTATION_INTERVAL}ms` }), []);
   const [alertIndex, setAlertIndex] = useState(0);
-  useAlertRotation(alerts.length, setAlertIndex);
+  useAlertRotation(alerts.length, setAlertIndex, ROTATION_INTERVAL);
 
   const currentAlert = alerts[alertIndex];
 
@@ -41,7 +44,7 @@ export default function AlertCarousel({ alerts }) {
         </div>
         {alerts.length > 1 && (
           <div className={classNames["countdown"]} key={currentAlert.id}>
-            <div className={classNames["countdown-bar"]} />
+            <div className={classNames["countdown-bar"]} style={animationStyle} />
           </div>
         )}
       </div>

--- a/src/components/AlertCarousel.module.css
+++ b/src/components/AlertCarousel.module.css
@@ -41,7 +41,7 @@
   }
 
   .countdown-bar {
-    animation: countdown-fill 20s linear forwards;
+    animation: countdown-fill linear forwards;
     background-color: darkgray;
     height: 100%;
     transform-origin: left center;

--- a/src/components/AlertCarousel.module.css
+++ b/src/components/AlertCarousel.module.css
@@ -6,6 +6,8 @@
   display: flex;
   align-items: center;
   gap: 1em;
+  overflow: hidden;
+  position: relative;
 }
 
 .alert-number {
@@ -26,4 +28,32 @@
 .alert-routes {
   display: flex;
   flex-wrap: nowrap;
+}
+
+@media not (prefers-reduced-motion: reduce) {
+  .countdown {
+    background-color: rgb(from darkgray r g b / 25%);
+    bottom: 0;
+    height: 0.2em;
+    left: 0;
+    position: absolute;
+    right: 0;
+  }
+
+  .countdown-bar {
+    animation: countdown-fill 20s linear forwards;
+    background-color: darkgray;
+    height: 100%;
+    transform-origin: left center;
+  }
+}
+
+@keyframes countdown-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
 }

--- a/src/hooks/useAlertRotation.js
+++ b/src/hooks/useAlertRotation.js
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-export default function useAlertRotation(alertsLength, setAlertIndex) {
+export default function useAlertRotation(alertsLength, setAlertIndex, rotationInterval) {
   useEffect(() => {
     if (alertsLength <= 1) {
       return;
@@ -8,7 +8,7 @@ export default function useAlertRotation(alertsLength, setAlertIndex) {
 
     const interval = setInterval(() => {
       setAlertIndex((index) => (index + 1) % alertsLength);
-    }, 20000);
+    }, rotationInterval);
     return () => clearInterval(interval);
-  }, [alertsLength, setAlertIndex]);
+  }, [alertsLength, setAlertIndex, rotationInterval]);
 }

--- a/src/hooks/useAlertRotation.js
+++ b/src/hooks/useAlertRotation.js
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+
+export default function useAlertRotation(alertsLength, setAlertIndex) {
+  useEffect(() => {
+    if (alertsLength <= 1) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setAlertIndex((index) => (index + 1) % alertsLength);
+    }, 20000);
+    return () => clearInterval(interval);
+  }, [alertsLength, setAlertIndex]);
+}


### PR DESCRIPTION
One thing that came up in yet another "how long does it take to read an alert" discussion was that if the alert takes too long to change you might not realize that it's _going_ to change. I've seen this progress-bar type indicator a few places.

https://github.com/user-attachments/assets/7b851ac5-fa76-4643-adac-50d76a033e74

Thoughts?